### PR TITLE
Harden parseDMS against untrusted input

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -61,6 +61,10 @@ func (c *cumulativeErrorParser) parseDMS(s, ref string) float64 {
 		m = -1
 	}
 
+	if n >= len(s) {
+		c.err = errors.New("malformed DMS (lat/long): " + s + " " + ref)
+		return 0
+	}
 	deg := c.parseFloat(s[:n])
 	min := c.parseFloat(s[n:])
 	deg += (min / 60.0)


### PR DESCRIPTION
I have a sample NMEA file from a slightly
noisy connection that contains a moderate amount
of junk data, and it was triggering lots of panics
in parseDMS. This turns them into errors.
